### PR TITLE
Keine Google Fonts mehr

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ If your Pull Request is accepted and merged into `main`, all changes will be aut
 
 Quickly hacked together, but it works. And it works in the following way:
 
+- Parse `./fonts.toml` and download the font files from the specified URLs.
+- Place the font files in the `fonts` directory.
 - Parse `./redirects.toml`.
 - Fetch Base CSS from jsdelivr. We are using [new.css](https://newcss.net).
 - Minify Custom CSS with rcssmin.

--- a/build.py
+++ b/build.py
@@ -8,6 +8,7 @@ from jinja2 import Environment, FileSystemLoader, StrictUndefined
 from rcssmin import cssmin
 
 REDIRECTS_PATH = "redirects.toml"
+FONTS_PATH = "fonts.toml"
 
 TEMPLATE_FOLDER_PATH = "./template"
 TEMPLATE_HTML = "index.j2"
@@ -27,6 +28,20 @@ def parse_redirects():
     with open(REDIRECTS_PATH, "r", encoding="utf-8") as f:
         return toml.load(f)
 
+def fetch_from_gfonts():
+    fonts_path = os.path.join(OUTPUT_FOLDER_PATH, "fonts")
+    if not os.path.isdir(fonts_path):
+        os.mkdir(fonts_path)
+
+    with open(FONTS_PATH, "r", encoding="utf-8") as f:
+        fonts = toml.load(f)
+    
+    for font in fonts:
+        font_file = os.path.join(fonts_path, f"{font}.woff2")
+        res = requests.get(fonts[font])
+        res.raise_for_status()
+        with open(font_file, "wb") as f:
+            f.write(res.content)
 
 def process_css():
     with open(os.path.join(OUTPUT_FOLDER_PATH, NEW_CSS_MIN), "wb") as f:
@@ -72,6 +87,7 @@ def main():
     data = parse_redirects()
     if not os.path.isdir(OUTPUT_FOLDER_PATH):
         os.mkdir(OUTPUT_FOLDER_PATH)
+    fetch_from_gfonts()
     process_css()
     shutil.copyfile("favicon.svg", os.path.join(OUTPUT_FOLDER_PATH, "favicon.svg"))
     with open(

--- a/fonts.toml
+++ b/fonts.toml
@@ -1,0 +1,3 @@
+inter400 = "https://fonts.gstatic.com/s/inter/v20/UcC73FwrK3iLTeHuS_nVMrMxCp50SjIa1ZL7.woff2"
+inter600 = "https://fonts.gstatic.com/s/inter/v20/UcC73FwrK3iLTeHuS_nVMrMxCp50SjIa1ZL7.woff2"
+inter700 = "https://fonts.gstatic.com/s/inter/v20/UcC73FwrK3iLTeHuS_nVMrMxCp50SjIa1ZL7.woff2"

--- a/template/index.j2
+++ b/template/index.j2
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>unia.xyz | Kurze URLs zu Seiten der Universität Augsburg</title>400;600;700
+    <title>unia.xyz | Kurze URLs zu Seiten der Universität Augsburg</title>
     <link rel="stylesheet" href="new.min.css">
     <link rel="stylesheet" href="unia.min.css">
     <link rel="icon" type="image/svg+xml" href="favicon.svg">

--- a/template/index.j2
+++ b/template/index.j2
@@ -4,13 +4,40 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>unia.xyz | Kurze URLs zu Seiten der Universität Augsburg</title>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&display=swap"
-          rel="stylesheet">
+    <title>unia.xyz | Kurze URLs zu Seiten der Universität Augsburg</title>400;600;700
     <link rel="stylesheet" href="new.min.css">
     <link rel="stylesheet" href="unia.min.css">
     <link rel="icon" type="image/svg+xml" href="favicon.svg">
 </head>
+
+<style>
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url(/fonts/inter400.woff2) format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 600;
+  font-display: swap;
+  src: url(/fonts/inter600.woff2) format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url(/fonts/inter700.woff2) format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+</style>
 
 <body>
 

--- a/template/index_en.j2
+++ b/template/index_en.j2
@@ -5,12 +5,39 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>unia.xyz | Short URLS to pages of the University of Augsburg</title>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&display=swap"
-          rel="stylesheet">
     <link rel="stylesheet" href="../new.min.css">
     <link rel="stylesheet" href="../unia.min.css">
     <link rel="icon" type="image/svg+xml" href="../favicon.svg">
 </head>
+
+<style>
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url(/fonts/inter400.woff2) format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 600;
+  font-display: swap;
+  src: url(/fonts/inter600.woff2) format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url(/fonts/inter700.woff2) format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+</style>
 
 <body>
 


### PR DESCRIPTION
Aus Datenschutzgründen werden die Font-Dateien von Google Fonts bereits im Build-Schritt heruntergeladen und von der eigenen Seite geliefert.